### PR TITLE
Ackermann Task2: Support ackermannization on uninterpreted sorts in BV

### DIFF
--- a/src/preprocessing/passes/ackermann.cpp
+++ b/src/preprocessing/passes/ackermann.cpp
@@ -298,7 +298,6 @@ Ackermann::Ackermann(PreprocessingPassContext* preprocContext)
       d_funcToSkolem(preprocContext->getUserContext()),
       d_sortsToSkolem(preprocContext->getUserContext()),
       d_logic(preprocContext->getLogicInfo())
-// TODO is it the correct way to initialize d_sortsToSkolem???
 {
 }
 

--- a/src/preprocessing/passes/ackermann.cpp
+++ b/src/preprocessing/passes/ackermann.cpp
@@ -265,7 +265,7 @@ void usortsToBitVectors(USortToBVSizeMap& usort_cardinality,
   {
     term = to_process[i];
     AlwaysAssert(term.getKind() != kind::STORE,
-                 "Cannot use eager bitblasting on QF_ABV formula with stores");
+                 "Cannot use ackermannization on QF_ABV formula with stores");
 
     updateUSortsCardinality(usort_cardinality, term);
 

--- a/src/preprocessing/passes/ackermann.cpp
+++ b/src/preprocessing/passes/ackermann.cpp
@@ -242,7 +242,7 @@ void collectUSortsToBV(std::unordered_set<unsigned>& used,
  * that, after the replacement, the different sorts will be converted into bit
  * vectors with different size.
  * The size is calculated to have enough capacity, that can accommodate the
- * terms occured in the original formula. */
+ * variables occured in the original formula. */
 void usortsToBitVectors(USortToBVSizeMap& usort_cardinality,
                         SubstitutionMap& sorts_to_skolem,
                         AssertionPipeline* assertions)

--- a/src/preprocessing/passes/ackermann.cpp
+++ b/src/preprocessing/passes/ackermann.cpp
@@ -187,9 +187,118 @@ void collectFunctionsAndLemmas(FunctionToArgsMap& fun_to_args,
 
 /* -------------------------------------------------------------------------- */
 
+/* Update the statistics for each uninterpreted sort */
+void updateUSortsCardinality(USortToBVSizeMap& usort_cardinality, TNode term)
+{
+  TypeNode type = term.getType();
+  if (type.isSort())
+  {
+    if (usort_cardinality.find(type) == usort_cardinality.end())
+    {
+      usort_cardinality.insert(make_pair(type, make_pair(0, 0)));
+    }
+    usort_cardinality[type].first = usort_cardinality[type].first + 1;
+  }
+}
+
+/* Given the lowest capacity requirements for each uninterpreted sorts, assign
+ * unique bit vector size. Get the converting map */
+void collectUSortsToBV(std::unordered_set<unsigned>& used,
+                       USortToBVSizeMap& usort_cardinality,
+                       vector<TNode>& vec,
+                       SubstitutionMap& sorts_to_skolem)
+{
+  NodeManager* nm = NodeManager::currentNM();
+
+  for (TNode term : vec)
+  {
+    TypeNode type = term.getType();
+    if (type.isSort())
+    {
+      unsigned size = usort_cardinality[type].second;
+      if (size == 0)
+      {
+        size = log2(usort_cardinality[type].first) + 1;
+        while (used.find(size) != used.end())
+        {
+          ++size;
+        }
+        usort_cardinality[type].second = size;
+        used.insert(size);
+      }
+      Node skolem = nm->mkSkolem("BVSKOLEM$$",
+                                 nm->mkBitVectorType(size),
+                                 "a variable created by the ackermannization "
+                                 "preprocessing pass for theory BV");
+      sorts_to_skolem.addSubstitution(term, skolem);
+    }
+  }
+}
+
+/* This is the top level of converting uninterpreted sorts to bit vectors.
+ * We use bfs to get all terms without duplications, and count the number of
+ * different terms for each uninterpreted sort. Then for each sort, we will
+ * assign a new bit vector type with a unique size. The unique size ensures
+ * that, after the replacement, the different sorts will be converted into bit
+ * vectors with different size.
+ * The size is calculated to have enough capacity, that can accommodate the
+ * terms occured in the original formula. */
+void usortsToBitVectors(USortToBVSizeMap& usort_cardinality,
+                        SubstitutionMap& sorts_to_skolem,
+                        AssertionPipeline* assertions)
+{
+  std::unordered_set<unsigned> used;
+  used.clear();
+  TNodeSet seen;
+  seen.clear();
+  std::vector<TNode> to_process;
+  for (Node& a : assertions->ref())
+  {
+    if (seen.find(a) == seen.end())
+    {
+      to_process.push_back(a);
+      seen.insert(a);
+    }
+  }
+  TNode term;
+  for (unsigned i = 0; i < to_process.size(); ++i)
+  {
+    term = to_process[i];
+    AlwaysAssert(term.getKind() != kind::STORE,
+                 "Cannot use eager bitblasting on QF_ABV formula with stores");
+
+    updateUSortsCardinality(usort_cardinality, term);
+
+    for (TNode a : term)
+    {
+      if (seen.find(a) == seen.end())
+      {
+        to_process.push_back(a);
+        seen.insert(a);
+      }
+    }
+  }
+
+  for (TNode a : to_process)
+  {
+    TypeNode type = a.getType();
+    if (type.isBitVector())
+    {
+      used.insert(type.getBitVectorSize());
+    }
+  }
+
+  collectUSortsToBV(used, usort_cardinality, to_process, sorts_to_skolem);
+}
+
+/* -------------------------------------------------------------------------- */
+
 Ackermann::Ackermann(PreprocessingPassContext* preprocContext)
     : PreprocessingPass(preprocContext, "ackermann"),
-      d_funcToSkolem(preprocContext->getUserContext())
+      d_funcToSkolem(preprocContext->getUserContext()),
+      d_sortsToSkolem(preprocContext->getUserContext()),
+      d_logic(preprocContext->getLogicInfo())
+// TODO is it the correct way to initialize d_sortsToSkolem???
 {
 }
 
@@ -216,9 +325,25 @@ PreprocessingPassResult Ackermann::applyInternal(
         i, d_funcToSkolem.apply((*assertionsToPreprocess)[i]));
   }
 
+  /* the current version only support BV for removing uninterpreted sorts */
+  if (d_logic.isTheoryEnabled(theory::THEORY_BV))
+  {
+    /* replace uninterpreted sorts to bitvector */
+    usortsToBitVectors(
+        d_usortCardinality, d_sortsToSkolem, assertionsToPreprocess);
+
+    for (unsigned i = 0, size = assertionsToPreprocess->size(); i < size; ++i)
+    {
+      Node old = (*assertionsToPreprocess)[i];
+      assertionsToPreprocess->replace(
+          i, d_sortsToSkolem.apply((*assertionsToPreprocess)[i]));
+      Trace("uninterpretedSorts-to-bv")
+          << "  " << old << " => " << (*assertionsToPreprocess)[i] << "\n";
+    }
+  }
+
   return PreprocessingPassResult::NO_CONFLICT;
 }
-
 
 /* -------------------------------------------------------------------------- */
 

--- a/src/preprocessing/passes/ackermann.cpp
+++ b/src/preprocessing/passes/ackermann.cpp
@@ -345,6 +345,7 @@ PreprocessingPassResult Ackermann::applyInternal(
   return PreprocessingPassResult::NO_CONFLICT;
 }
 
+
 /* -------------------------------------------------------------------------- */
 
 }  // namespace passes

--- a/src/preprocessing/passes/ackermann.h
+++ b/src/preprocessing/passes/ackermann.h
@@ -27,7 +27,6 @@
 #define CVC4__PREPROCESSING__PASSES__ACKERMANN_H
 
 #include <cmath>
-#include <cstring>
 #include <unordered_map>
 #include <unordered_set>
 #include "expr/node.h"

--- a/src/preprocessing/passes/ackermann.h
+++ b/src/preprocessing/passes/ackermann.h
@@ -26,7 +26,10 @@
 #ifndef CVC4__PREPROCESSING__PASSES__ACKERMANN_H
 #define CVC4__PREPROCESSING__PASSES__ACKERMANN_H
 
+#include <cmath>
+#include <cstring>
 #include <unordered_map>
+#include <unordered_set>
 #include "expr/node.h"
 #include "preprocessing/preprocessing_pass.h"
 #include "preprocessing/preprocessing_pass_context.h"
@@ -38,6 +41,8 @@ namespace passes {
 using TNodeSet = std::unordered_set<TNode, TNodeHashFunction>;
 using FunctionToArgsMap =
     std::unordered_map<TNode, TNodeSet, TNodeHashFunction>;
+using USortToBVSizeMap = std::
+    unordered_map<TypeNode, pair<unsigned, unsigned>, TypeNode::HashFunction>;
 
 class Ackermann : public PreprocessingPass
 {
@@ -64,6 +69,14 @@ class Ackermann : public PreprocessingPass
   /* Map each function term to the new Skolem variable created by
    * ackermannization */
   theory::SubstitutionMap d_funcToSkolem;
+  /* Map each uninterpreted sort to the new Skolem variable created by
+   * ackermannization */
+  theory::SubstitutionMap d_sortsToSkolem;
+  /* Map each Uninterpreted sort to a pair of integers.
+   * The first value is the lowest capacity that the targeting BV should have
+   * The second value is the size of the BV which will convert into */
+  USortToBVSizeMap d_usortCardinality;
+  LogicInfo d_logic;
 };
 
 }  // namespace passes

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -167,6 +167,10 @@ set(regress_0_tests
   regress0/bv/ackermann2.smt2
   regress0/bv/ackermann3.smt2
   regress0/bv/ackermann4.smt2
+        regress0/bv/ackermann5.smt2
+        regress0/bv/ackermann6.smt2
+        regress0/bv/ackermann7.smt2
+        regress0/bv/ackermann8.smt2
   regress0/bv/bool-model.smt2
   regress0/bv/bool-to-bv-all.smt2
   regress0/bv/bool-to-bv-ite.smt2

--- a/test/regress/CMakeLists.txt
+++ b/test/regress/CMakeLists.txt
@@ -167,10 +167,10 @@ set(regress_0_tests
   regress0/bv/ackermann2.smt2
   regress0/bv/ackermann3.smt2
   regress0/bv/ackermann4.smt2
-        regress0/bv/ackermann5.smt2
-        regress0/bv/ackermann6.smt2
-        regress0/bv/ackermann7.smt2
-        regress0/bv/ackermann8.smt2
+  regress0/bv/ackermann5.smt2
+  regress0/bv/ackermann6.smt2
+  regress0/bv/ackermann7.smt2
+  regress0/bv/ackermann8.smt2
   regress0/bv/bool-model.smt2
   regress0/bv/bool-to-bv-all.smt2
   regress0/bv/bool-to-bv-ite.smt2

--- a/test/regress/regress0/bv/ackermann5.smt2
+++ b/test/regress/regress0/bv/ackermann5.smt2
@@ -1,0 +1,31 @@
+; COMMAND-LINE: --ackermann --no-check-models --no-check-proofs --no-check-unsat-cores
+; EXPECT: sat
+(set-logic QF_UFBV)
+
+(declare-sort S 0)
+(declare-sort T 0)
+
+(declare-fun s1 () S)
+(declare-fun s2 () S)
+(declare-fun t1 () T)
+(declare-fun t2 () T)
+
+(declare-fun a () (_ BitVec 4))
+(declare-fun b () (_ BitVec 4))
+
+(declare-fun f (S) (_ BitVec 4))
+(declare-fun g (S) S)
+(declare-fun h (T) S)
+(declare-fun i (T) T)
+
+(assert (= (f s1) (bvand a b)))
+(assert (= (f s2) (bvand a b)))
+
+(assert (= (f (g s1)) (f (h (i t1)))))
+(assert (= (f (g (h (i t2)))) (f (h (i t2)))))
+(assert (= t1 t2))
+(assert (= s1 (h (i t2))))
+
+(check-sat)
+(exit)
+

--- a/test/regress/regress0/bv/ackermann6.smt2
+++ b/test/regress/regress0/bv/ackermann6.smt2
@@ -1,0 +1,31 @@
+; COMMAND-LINE: --ackermann --no-check-models --no-check-proofs --no-check-unsat-cores
+; EXPECT: unsat
+(set-logic QF_UFBV)
+
+(declare-sort S 0)
+(declare-sort T 0)
+
+(declare-fun s1 () S)
+(declare-fun s2 () S)
+(declare-fun t1 () T)
+(declare-fun t2 () T)
+
+(declare-fun a () (_ BitVec 4))
+(declare-fun b () (_ BitVec 4))
+
+(declare-fun f (S) (_ BitVec 4))
+(declare-fun g (S) S)
+(declare-fun h (T) S)
+(declare-fun i (T) T)
+
+(assert (= (f s1) (bvand a b)))
+(assert (= (f s2) (bvand a b)))
+
+(assert (= (f (g s1)) (f (h (i t1)))))
+(assert (not (= (f (g (h (i t2)))) (f (h (i t2))))))
+(assert (= t1 t2))
+(assert (= s1 (h (i t2))))
+
+(check-sat)
+(exit)
+

--- a/test/regress/regress0/bv/ackermann7.smt2
+++ b/test/regress/regress0/bv/ackermann7.smt2
@@ -1,0 +1,26 @@
+; COMMAND-LINE: --ackermann --no-check-models --no-check-proofs --no-check-unsat-cores
+; EXPECT: sat
+(set-logic QF_UFBV)
+
+(declare-sort S 0)
+(declare-sort T 0)
+
+(declare-fun s1 () S)
+(declare-fun s2 () S)
+(declare-fun s3 () S)
+
+(declare-fun t1 () T)
+(declare-fun t2 () T)
+(declare-fun t3 () T)
+
+(assert (not (= s1 s2)))
+(assert (not (= s2 s3)))
+(assert (not (= s3 s1)))
+
+(assert (not (= t1 t2)))
+(assert (not (= t2 t3)))
+(assert (not (= t3 t1)))
+
+(check-sat)
+(exit)
+

--- a/test/regress/regress0/bv/ackermann8.smt2
+++ b/test/regress/regress0/bv/ackermann8.smt2
@@ -1,0 +1,26 @@
+; COMMAND-LINE: --ackermann --no-check-models --no-check-proofs --no-check-unsat-cores
+; EXPECT: unsat
+(set-logic QF_UFBV)
+
+(declare-sort S 0)
+(declare-sort T 0)
+
+(declare-fun s1 () S)
+(declare-fun s2 () S)
+(declare-fun s3 () S)
+
+(declare-fun a () (_ BitVec 1))
+(declare-fun b () (_ BitVec 1))
+(declare-fun c () (_ BitVec 1))
+
+(assert (not (= s1 s2)))
+(assert (not (= s2 s3)))
+(assert (not (= s3 s1)))
+
+(assert (not (= a b)))
+(assert (not (= b c)))
+(assert (not (= c a)))
+
+(check-sat)
+(exit)
+


### PR DESCRIPTION
Support ackermannization on uninterpreted sorts in BV. For uninterpreted sorts, we create a new Bit Vector sort to replace it. We guarantee that the new Bit Vector will have a fresh size, so that different sorts will be translated into different Bit Vector Sorts. Besides, if for an uninterpreted sort S, the number of variables within sort S is n, the replacing Bit Vector will have size at least (log n)+1.